### PR TITLE
Remove recovered cases estimation

### DIFF
--- a/simulator/pages/seir.py
+++ b/simulator/pages/seir.py
@@ -41,17 +41,6 @@ def prepare_for_r0_estimation(df):
     )
 
 
-def estimate_active_cases(cases, gamma_sup):
-    return (
-        cases
-        .assign(estimatedActiveCases = lambda df: df['newCases'].rolling(window=int(gamma_sup),
-                                                                         min_periods=1)
-                                                                .sum()
-                )
-        .assign(estimatedRecoveredCases = lambda df: df['totalCases'] - df['estimatedActiveCases'])
-    )
-
-
 @st.cache
 def make_brazil_cases(cases_df):
     return (cases_df
@@ -145,15 +134,11 @@ def make_param_widgets(NEIR0, r0_samples=None, defaults=DEFAULT_PARAMS):
 
 
 @st.cache
-def make_NEIR0(cases_df, population_df, place, date, gamma_sup=DEFAULT_PARAMS['gamma_inv_dist'][1]):
+def make_NEIR0(cases_df, population_df, place, date):
     N0 = population_df[place]
-    I0 = (cases_df[place]
-          .pipe(estimate_active_cases, gamma_sup)
-            ['estimatedActiveCases'][date])
+    I0 = cases_df[place]['totalCases'][date]
     E0 = 2*I0
-    R0 = (cases_df[place]
-          .pipe(estimate_active_cases, gamma_sup)
-            ['estimatedRecoveredCases'][date])
+    R0 = 0
     return (N0, E0, I0, R0)
 
 


### PR DESCRIPTION
This PR reverts the recovered cases estimation. 
Infected cases should be overestimated as discussed.

Current simulation values:
![image](https://user-images.githubusercontent.com/21134508/82256644-19951480-992d-11ea-80a7-be11f4f881a6.png)

PR simulation values:
![image](https://user-images.githubusercontent.com/21134508/82256490-d0dd5b80-992c-11ea-9606-6ddd65c61906.png)
