### PR TITLE
Suporte a diferentes taxas de letalidade no arquivo de parâmetros padrão.

### DIFF
--- a/data/params_example.csv
+++ b/data/params_example.csv
@@ -1,5 +1,5 @@
-place,fator_subr,t_max,lethality_mean,Ventiladores,Leitos
-SP,66,,,,
-São Paulo/SP,42,55,,,
-SC,,42,,,0.21
-PR,,,8,0.0066,
+place,fator_subr,t_max,lethality_mean,Ventiladores,Leitos,leth_ewm,leth_est,leth_age
+SP,,,,,,,6.5,
+SC,,,,,,,,
+PR,,42,,,0.21,6.8,7,
+,,,8,0.0062,,,,10

--- a/simulator/pages/seir.py
+++ b/simulator/pages/seir.py
@@ -100,10 +100,10 @@ def make_date_options(cases_df, place):
             .index
             .strftime('%Y-%m-%d'))
 
-def make_death_widget(lethality_mean_est, lethality_mean_place, widget_values):
+def make_death_widget(lethality_mean_est, lethality_mean_place, lethality_type, widget_values):
     lethality_mean = hideable(lethality_mean_place.number_input,
-                              show=not('lethality_mean' in widget_values),
-                              hidden_value=widget_values.get('lethality_mean'))(
+                              show=not(lethality_type in widget_values),
+                              hidden_value=widget_values.get(lethality_type))(
             ('Taxa de letalidade (em %).'),
             min_value=0.0, max_value=100.0, step=0.1,
             value=lethality_mean_est)
@@ -425,7 +425,7 @@ def write():
                                    index=options_place.get_loc(DEFAULT_PLACE),
                                    format_func=global_format_func)
     try:
-        raw_widget_values = (pd.read_csv('data/param.csv')
+        raw_widget_values = (pd.read_csv('data/params.csv')
                           .set_index('place')
                           .T
                           .to_dict()
@@ -435,10 +435,10 @@ def write():
         widget_values = {}
 
     if widget_values:
+        st.markdown("---")
         st.markdown("### Parâmetros carregados")
         st.write(f"Foram carregados parâmetros pré-selecionados para a unidade escolhida:  **{w_place}**.")
         st.write('  \n'.join(f"{param}: {value}" for param, value in widget_values.items()))
-        st.markdown("---")
 
     options_date = make_date_options(cases_df, w_place)
     w_date = st.sidebar.selectbox('Data inicial',
@@ -449,7 +449,7 @@ def write():
 
     # Configurações da simulação
     st.markdown(texts.SIMULATION_CONFIG)
-    
+
     # Estimativa R0
     st.markdown(texts.r0_ESTIMATION_TITLE)
     should_estimate_r0 = st.checkbox(
@@ -496,7 +496,7 @@ def write():
     params_intro_txt, seir0_dict, other_params_txt = texts.make_SIMULATION_PARAMS(SEIR0, dists,
                                              should_estimate_r0)
 
-    
+
     #Outros parâmetros
     st.markdown(params_intro_txt)
     st.write(pd.DataFrame(seir0_dict).set_index("Compartimento"))
@@ -526,7 +526,9 @@ def write():
                                                                     w_granularity, w_place,
                                                                     lethality_type)
     lethality_mean = make_death_widget(lethality_mean_est,
-                                       lethality_mean_place, widget_values)
+                                       lethality_mean_place,
+                                       lethality_type,
+                                       widget_values)
     if show_leth_age_message:
         st.markdown(
         f"**Este estado não apresentou dados de faixa etária."


### PR DESCRIPTION
É possível salvar/carregar as três taxas diferentes no momento. 
No arquivo, `leth_est` corresponde à taxa estimada, `leth_age` à taxa ponderada por faixa etária e `leth_ewm` à média móvel.
Adicionei exemplos no arquivo `data/params_example.csv`.